### PR TITLE
add handling of when reference column is not the best

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -193,7 +193,13 @@ computeBayesFactor <- function(bootstrapMetricMatrix,
     M <- as.data.frame(bootstrapMetricMatrix - bootstrapMetricMatrix[,refPredIndex])
     K <- apply(M ,2, function(x) {
       k <- sum(x >= 0)/sum(x < 0)
-      return(k)
+      
+      # Logic handles whether reference column is the best set of predictions.
+      if(sum(x >= 0) > sum(x < 0)){
+        return(k)
+      }else{
+        return(1/k)
+      }
     })
     K[refPredIndex] <- 0
     if(invertBayes == T){K <- 1/K}


### PR DESCRIPTION
(Adding change for @allaway )

This change will handle the case for when the reference column is **not** the best set of predictions, i.e. baseline model.  When this happens, the inversion of K (BF) will change, depending on which submission it is being compared to.

I did test this change with a sample bootstapped matrix to ensure the behavior will not change when the reference column is the best:

```
computeBayesFactorWhereRefIsNotBest <- function(bootstrapMetricMatrix,
                               refPredIndex,
                               invertBayes){

    M <- as.data.frame(bootstrapMetricMatrix - bootstrapMetricMatrix[,refPredIndex])
    K <- apply(M ,2, function(x) {
      k <- sum(x >= 0)/sum(x < 0)
      if(sum(x >= 0) > sum(x < 0)){
      return(k)
      }else{
      return(1/k)
      }
    })
    if(invertBayes == T){K <- 1/K}
    K[refPredIndex] <- 0

    return(K)
}
```
```
> computeBayesFactorWhereRefIsNotBest(boot, refPredIndex=1, invertBayes=F) %>%
+     as_tibble(rownames = "submission") %>%
+     rename(bayes = value)
# A tibble: 3 x 2
   submission                     bayes
   <chr>                          <dbl>
 1 team A                         0   
 2 team B                         8.09
 3 team C                         Inf   

> computeBayesFactor(boot, refPredIndex=1, invertBayes=F) %>%
+     as_tibble(rownames = "submission") %>%
+     rename(bayes = value) 
# A tibble: 3 x 2
   submission                     bayes
   <chr>                          <dbl>
 1 team A                         0   
 2 team B                         8.09
 3 team C                         Inf   
```